### PR TITLE
Adding items to support powershell commands, handle I/O issues on win32 platforms

### DIFF
--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -18,6 +18,7 @@ async def shell_run_command(
     env: Optional[dict] = None,
     helper_command: Optional[str] = None,
     shell: str = "bash",
+    extension: Optional[str] = None,
     return_all: bool = False,
     stream_level: int = logging.INFO,
 ) -> Union[List, str]:
@@ -34,6 +35,7 @@ async def shell_run_command(
             Can be used to change directories, define helper functions, etc.
             for different commands in a flow.
         shell: Shell to run the command with.
+        extension: File extension to be appended to the command to be executed.
         return_all: Whether this task should return all lines of stdout as a list,
             or just the last line as a string.
         stream_level: The logging level of the stream;
@@ -60,12 +62,9 @@ async def shell_run_command(
     current_env = os.environ.copy()
     current_env.update(env or {})
 
-    if shell.lower() == "powershell":
-        suffix = ".ps1"
-    else:
-        suffix = ""
+    extension = ".ps1" if shell.lower() == "powershell" else extension
 
-    with tempfile.NamedTemporaryFile(prefix="prefect-", suffix=suffix, delete=False) as tmp:
+    with tempfile.NamedTemporaryFile(prefix="prefect-", suffix=extension, delete=False) as tmp:
         if helper_command:
             tmp.write(helper_command.encode())
             tmp.write(os.linesep.encode())
@@ -94,7 +93,9 @@ async def shell_run_command(
                 )
                 raise RuntimeError(msg)
         
-        if os.path.exists(tmp.name):
+        try:
+            os.path.exists(tmp.name)
+        finally:
             os.remove(tmp.name)
 
     line = lines[-1] if lines else ""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+import sys
+sys.path.append('.')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
 import sys
-sys.path.append('.')
+
+sys.path.append(".")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 
@@ -15,7 +16,6 @@ def prefect_caplog(caplog):
         logger.propagate = False
 
 
-
 @pytest.fixture(scope="function")
 def prefect_task_runs_caplog(prefect_caplog):
     logger = logging.getLogger("prefect.task_runs")
@@ -27,4 +27,3 @@ def prefect_task_runs_caplog(prefect_caplog):
         yield prefect_caplog
     finally:
         logger.propagate = False
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import logging
+import pytest
+
+
+@pytest.fixture(scope="function")
+def prefect_caplog(caplog):
+    logger = logging.getLogger("prefect")
+
+    # TODO: Determine a better pattern for this and expose for all tests
+    logger.propagate = True
+
+    try:
+        yield caplog
+    finally:
+        logger.propagate = False
+
+
+
+@pytest.fixture(scope="function")
+def prefect_task_runs_caplog(prefect_caplog):
+    logger = logging.getLogger("prefect.task_runs")
+
+    # TODO: Determine a better pattern for this and expose for all tests
+    logger.propagate = True
+
+    try:
+        yield prefect_caplog
+    finally:
+        logger.propagate = False
+

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,33 +8,7 @@ from prefect import flow
 from prefect_shell.commands import shell_run_command
 
 
-@pytest.fixture
-def prefect_caplog(caplog):
-    logger = logging.getLogger("prefect")
-
-    # TODO: Determine a better pattern for this and expose for all tests
-    logger.propagate = True
-
-    try:
-        yield caplog
-    finally:
-        logger.propagate = False
-
-
-@pytest.fixture
-def prefect_task_runs_caplog(prefect_caplog):
-    logger = logging.getLogger("prefect.task_runs")
-
-    # TODO: Determine a better pattern for this and expose for all tests
-    logger.propagate = True
-
-    try:
-        yield prefect_caplog
-    finally:
-        logger.propagate = False
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="")
+@pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")
 def test_shell_run_command_error(prefect_task_runs_caplog):
     @flow
     def test_flow():
@@ -42,12 +16,12 @@ def test_shell_run_command_error(prefect_task_runs_caplog):
 
     match = "No such file or directory"
     with pytest.raises(RuntimeError, match=match):
-        test_flow().result(raise_on_failure=True)
+        test_flow()
 
     assert len(prefect_task_runs_caplog.records) == 0
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="")
+@pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")
 def test_shell_run_command(prefect_task_runs_caplog):
     prefect_task_runs_caplog.set_level(logging.INFO)
     echo_msg = "_THIS_ IS WORKING!!!!"
@@ -60,7 +34,7 @@ def test_shell_run_command(prefect_task_runs_caplog):
     assert echo_msg in prefect_task_runs_caplog.text
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="")
+@pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")
 def test_shell_run_command_stream_level(prefect_task_runs_caplog):
     prefect_task_runs_caplog.set_level(logging.WARNING)
     echo_msg = "_THIS_ IS WORKING!!!!"
@@ -76,7 +50,7 @@ def test_shell_run_command_stream_level(prefect_task_runs_caplog):
     assert echo_msg in prefect_task_runs_caplog.text
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="")
+@pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")
 def test_shell_run_command_helper_command():
     @flow
     def test_flow():
@@ -85,7 +59,7 @@ def test_shell_run_command_helper_command():
     assert test_flow() == os.path.expandvars("$HOME")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="")
+@pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")
 def test_shell_run_command_return_all():
     @flow
     def test_flow():
@@ -94,7 +68,7 @@ def test_shell_run_command_return_all():
     assert test_flow() == ["work!", "yes!"]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="")
+@pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")
 def test_shell_run_command_no_output():
     @flow
     def test_flow():
@@ -103,7 +77,7 @@ def test_shell_run_command_no_output():
     assert test_flow() == ""
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="")
+@pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")
 def test_shell_run_command_uses_current_env():
     @flow
     def test_flow():
@@ -112,7 +86,7 @@ def test_shell_run_command_uses_current_env():
     assert test_flow() == os.environ["HOME"]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="")
+@pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")
 def test_shell_run_command_update_current_env():
     @flow
     def test_flow():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 
 import pytest
 from prefect import flow
@@ -33,6 +34,7 @@ def prefect_task_runs_caplog(prefect_caplog):
         logger.propagate = False
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="")
 def test_shell_run_command_error(prefect_task_runs_caplog):
     @flow
     def test_flow():
@@ -45,6 +47,7 @@ def test_shell_run_command_error(prefect_task_runs_caplog):
     assert len(prefect_task_runs_caplog.records) == 0
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="")
 def test_shell_run_command(prefect_task_runs_caplog):
     prefect_task_runs_caplog.set_level(logging.INFO)
     echo_msg = "_THIS_ IS WORKING!!!!"
@@ -57,6 +60,7 @@ def test_shell_run_command(prefect_task_runs_caplog):
     assert echo_msg in prefect_task_runs_caplog.text
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="")
 def test_shell_run_command_stream_level(prefect_task_runs_caplog):
     prefect_task_runs_caplog.set_level(logging.WARNING)
     echo_msg = "_THIS_ IS WORKING!!!!"
@@ -72,6 +76,7 @@ def test_shell_run_command_stream_level(prefect_task_runs_caplog):
     assert echo_msg in prefect_task_runs_caplog.text
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="")
 def test_shell_run_command_helper_command():
     @flow
     def test_flow():
@@ -80,6 +85,7 @@ def test_shell_run_command_helper_command():
     assert test_flow() == os.path.expandvars("$HOME")
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="")
 def test_shell_run_command_return_all():
     @flow
     def test_flow():
@@ -88,6 +94,7 @@ def test_shell_run_command_return_all():
     assert test_flow() == ["work!", "yes!"]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="")
 def test_shell_run_command_no_output():
     @flow
     def test_flow():
@@ -96,6 +103,7 @@ def test_shell_run_command_no_output():
     assert test_flow() == ""
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="")
 def test_shell_run_command_uses_current_env():
     @flow
     def test_flow():
@@ -104,6 +112,7 @@ def test_shell_run_command_uses_current_env():
     assert test_flow() == os.environ["HOME"]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="")
 def test_shell_run_command_update_current_env():
     @flow
     def test_flow():

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -1,0 +1,164 @@
+import logging
+import os
+import sys
+import re
+
+import pytest
+from prefect import flow
+
+from prefect_shell.commands import shell_run_command
+
+
+@pytest.fixture
+def prefect_caplog(caplog):
+    logger = logging.getLogger("prefect")
+
+    # TODO: Determine a better pattern for this and expose for all tests
+    logger.propagate = True
+
+    try:
+        yield caplog
+    finally:
+        logger.propagate = False
+
+
+@pytest.fixture
+def prefect_task_runs_caplog(prefect_caplog):
+    logger = logging.getLogger("prefect.task_runs")
+
+    # TODO: Determine a better pattern for this and expose for all tests
+    logger.propagate = True
+
+    try:
+        yield prefect_caplog
+    finally:
+        logger.propagate = False
+
+
+# TODO: prefect futures result not being returned here, getting AttributeError: 'str' object has no attribute 'result'
+# @pytest.mark.skipif(sys.platform != "win32", reason="")
+# def test_shell_run_command_error_windows(prefect_task_runs_caplog):
+#     @flow
+#     def test_flow():
+#         return shell_run_command(command="ls this/is/invalid", return_all=True, shell="powershell")
+
+#     homedir = os.environ["USERPROFILE"]
+#     match = f"ls : Cannot find path {homedir}\\this\\is\\invalid because it does not exist."
+#     with pytest.raises(RuntimeError, match=match):
+#         test_flow().result(raise_on_failure=True)
+
+#     assert len(prefect_task_runs_caplog.records) == 0
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="")
+def test_shell_run_command_windows(prefect_task_runs_caplog):
+    prefect_task_runs_caplog.set_level(logging.INFO)
+    echo_msg = "_THIS_ IS WORKING!!!!"
+
+    @flow
+    def test_flow():
+        msg = shell_run_command(command=f"echo {echo_msg}", return_all=True, shell="powershell")
+        return " ".join(word.replace("\r", "") for word in msg)
+
+    print(prefect_task_runs_caplog.text)
+
+    assert test_flow() == echo_msg
+    assert echo_msg in prefect_task_runs_caplog.text.replace("\r\n\n", "").replace("\r\n", " ")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="")
+def test_shell_run_command_stream_level_windows(prefect_task_runs_caplog):
+    prefect_task_runs_caplog.set_level(logging.WARNING)
+    echo_msg = "_THIS_ IS WORKING!!!!"
+
+    @flow
+    def test_flow():
+        msg = shell_run_command(
+            command=f"echo {echo_msg}",
+            stream_level=logging.WARNING,
+            return_all=True,
+            shell="powershell",
+        )
+        return " ".join(word.replace("\r", "") for word in msg)
+
+    print(prefect_task_runs_caplog.text)
+
+    assert test_flow() == echo_msg
+    assert echo_msg in prefect_task_runs_caplog.text.replace("\r\n\n", "").replace("\r\n", " ")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="")
+def test_shell_run_command_helper_command_windows():
+    @flow
+    def test_flow():
+        return shell_run_command(command="Get-Location", helper_command="cd $env:USERPROFILE", shell="powershell")
+
+    assert test_flow() == os.path.expandvars("$USERPROFILE")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="")
+def test_shell_run_command_return_all():
+    @flow
+    def test_flow():
+        return shell_run_command(command="echo 'work!'; echo 'yes!'", return_all=True, shell="powershell")
+
+    result = test_flow()
+    assert result[0].rstrip() == "work!"
+    assert result[1].rstrip() == "yes!"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="")
+def test_shell_run_command_no_output_windows():
+    @flow
+    def test_flow():
+        return shell_run_command(command="sleep 1", shell="powershell")
+
+    assert test_flow() == ""
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="")
+def test_shell_run_command_uses_current_env_windows():
+    @flow
+    def test_flow():
+        return shell_run_command(command="echo $env:USERPROFILE", return_all=True, shell="powershell")
+
+    result = test_flow()
+    assert result[0].rstrip() == os.environ["USERPROFILE"]
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="")
+def test_shell_run_command_update_current_env_windows():
+    @flow
+    def test_flow():
+        return shell_run_command(
+            command="echo $env:USERPROFILE ; echo $env:TEST_VAR",
+            helper_command = "$env:TEST_VAR = 'test value'",
+            env={"TEST_VAR": "test value"},
+            return_all=True,
+            shell="powershell",
+        )
+
+    result = test_flow()
+    assert result[0] == os.environ["USERPROFILE"]
+    assert result[1] == "test value"
+
+@pytest.mark.skipif(sys.platform != "win32", reason="")
+def test_shell_run_command_ensure_suffix_ps1():
+    @flow
+    def test_flow():
+        return shell_run_command(command="1 + 1", shell="powershell", extension=".zzz")
+    
+    result = test_flow()
+    assert result == "2"
+
+@pytest.mark.skipif(sys.platform != "win32", reason="")
+def test_shell_run_command_ensure_tmp_file_removed():
+    @flow
+    def test_flow():
+        temp_dir = os.environ["TEMP"]
+        return shell_run_command(command="echo 'clean up after yourself!'", shell="powershell", dir=f"{temp_dir}\\prefect-cleanup")
+    
+    result = test_flow()
+    temp_dir = os.environ["TEMP"]
+    test_dir = f"{temp_dir}/prefect-cleanup"
+    assert os.path.exists(test_dir) == False

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -1,7 +1,7 @@
+import glob
 import logging
 import os
 import sys
-import glob
 
 import pytest
 from prefect import flow
@@ -9,15 +9,18 @@ from prefect import flow
 from prefect_shell.commands import shell_run_command
 
 
-# TODO: prefect futures result not being returned here, getting AttributeError: 'str' object has no attribute 'result'
 @pytest.mark.skipif(sys.platform != "win32", reason="see test_commands.py")
 def test_shell_run_command_error_windows(prefect_task_runs_caplog):
     @flow
     def test_flow():
-        return shell_run_command(command="ls this/is/invalid", return_all=True, shell="powershell")
+        return shell_run_command(
+            command="ls this/is/invalid", return_all=True, shell="powershell"
+        )
 
     homedir = os.environ["USERPROFILE"]
-    match = f"ls : Cannot find path {homedir}\\this\\is\\invalid because it does not exist."
+    match = (
+        f"ls : Cannot find path {homedir}\\this\\is\\invalid because it does not exist."
+    )
     with pytest.raises(RuntimeError, match=match):
         test_flow()
 
@@ -31,13 +34,17 @@ def test_shell_run_command_windows(prefect_task_runs_caplog):
 
     @flow
     def test_flow():
-        msg = shell_run_command(command=f"echo {echo_msg}", return_all=True, shell="powershell")
+        msg = shell_run_command(
+            command=f"echo {echo_msg}", return_all=True, shell="powershell"
+        )
         return " ".join(word.replace("\r", "") for word in msg)
 
     print(prefect_task_runs_caplog.text)
 
     assert test_flow() == echo_msg
-    assert echo_msg in prefect_task_runs_caplog.text.replace("\r\n\n", "").replace("\r\n", " ")
+    assert echo_msg in prefect_task_runs_caplog.text.replace("\r\n\n", "").replace(
+        "\r\n", " "
+    )
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="see test_commands.py")
@@ -58,14 +65,20 @@ def test_shell_run_command_stream_level_windows(prefect_task_runs_caplog):
     print(prefect_task_runs_caplog.text)
 
     assert test_flow() == echo_msg
-    assert echo_msg in prefect_task_runs_caplog.text.replace("\r\n\n", "").replace("\r\n", " ")
+    assert echo_msg in prefect_task_runs_caplog.text.replace("\r\n\n", "").replace(
+        "\r\n", " "
+    )
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="see test_commands.py")
 def test_shell_run_command_helper_command_windows():
     @flow
     def test_flow():
-        return shell_run_command(command="Get-Location", helper_command="cd $env:USERPROFILE", shell="powershell")
+        return shell_run_command(
+            command="Get-Location",
+            helper_command="cd $env:USERPROFILE",
+            shell="powershell",
+        )
 
     assert test_flow() == os.path.expandvars("$USERPROFILE")
 
@@ -74,7 +87,9 @@ def test_shell_run_command_helper_command_windows():
 def test_shell_run_command_return_all():
     @flow
     def test_flow():
-        return shell_run_command(command="echo 'work!'; echo 'yes!'", return_all=True, shell="powershell")
+        return shell_run_command(
+            command="echo 'work!'; echo 'yes!'", return_all=True, shell="powershell"
+        )
 
     result = test_flow()
     assert result[0].rstrip() == "work!"
@@ -94,7 +109,9 @@ def test_shell_run_command_no_output_windows():
 def test_shell_run_command_uses_current_env_windows():
     @flow
     def test_flow():
-        return shell_run_command(command="echo $env:USERPROFILE", return_all=True, shell="powershell")
+        return shell_run_command(
+            command="echo $env:USERPROFILE", return_all=True, shell="powershell"
+        )
 
     result = test_flow()
     assert result[0].rstrip() == os.environ["USERPROFILE"]
@@ -106,7 +123,7 @@ def test_shell_run_command_update_current_env_windows():
     def test_flow():
         return shell_run_command(
             command="echo $env:USERPROFILE ; echo $env:TEST_VAR",
-            helper_command = "$env:TEST_VAR = 'test value'",
+            helper_command="$env:TEST_VAR = 'test value'",
             env={"TEST_VAR": "test value"},
             return_all=True,
             shell="powershell",
@@ -116,22 +133,25 @@ def test_shell_run_command_update_current_env_windows():
     assert result[0] == os.environ["USERPROFILE"]
     assert result[1] == "test value"
 
+
 @pytest.mark.skipif(sys.platform != "win32", reason="see test_commands.py")
 def test_shell_run_command_ensure_suffix_ps1():
     @flow
     def test_flow():
         return shell_run_command(command="1 + 1", shell="powershell", extension=".zzz")
-    
+
     result = test_flow()
     assert result == "2"
+
 
 @pytest.mark.skipif(sys.platform != "win32", reason="see test_commands.py")
 def test_shell_run_command_ensure_tmp_file_removed():
     @flow
     def test_flow():
-        temp_dir = os.environ["TEMP"]
-        return shell_run_command(command="echo 'clean up after yourself!'", shell="powershell")
-    
-    result = test_flow()
+        return shell_run_command(
+            command="echo 'clean up after yourself!'", shell="powershell"
+        )
+
+    test_flow()
     temp_dir = os.environ["TEMP"]
     assert len(glob.glob(f"{temp_dir}\\prefect-*.ps1")) == 0


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-shell 🎉!

## Summary
We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->

- Added variable `suffix` to provide value for `tempfile.NamedTemporaryFile` argument `suffix`, specifically for handling powershell scripts when 'powershell' is provided to `shell`. Can be expanded upon in the future if need be.
- Set `tempfile.NamedTemporaryFile` argument `delete` to False. The temp file was being deleted prematurely.
- Replaced `tmp.flush()` with `tmp.close()`, as flush was not fully relinquishing control of the temp file.
- Explicity deleting the temp file after the process has executed, first checking that the path exists.

<!-- Link to issue -->
#36 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->
```
from prefect import flow
from prefect_shell.commands import *

h = "echo 'Hello world!'"
c = "echo 'Is this thing on?'"

@flow
def do_thing():
    shell_run_command(command=c, helper_command=h, shell='powershell', return_all=True)

if __name__ = '__main__':
    do_thing()
```
Prior to the change:
`RuntimeException: coroutine 'shell_run_command' was never awaited`

After change:
```
Hello world!
Is this thing on?
```