### PR TITLE
Add shell_run_command(cwd=) argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Released on October 11th, 2022.
 
 ### Added
 
-- Added `cwd` keyword argument in `shell_run_command`
+- Added `cwd` keyword argument in `shell_run_command` - [#41](https://github.com/PrefectHQ/prefect-shell/pull/41)
 
 
 ## 0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+
+## 0.1.3
+
+Released on October 11th, 2022.
+
+### Added
+
+- Added `cwd` keyword argument in `shell_run_command`
+
+
 ## 0.1.2
 
 Released on October 7th, 2022.
@@ -54,4 +64,3 @@ Released on March 9th, 2022.
 ### Added
 
 - `shell_run_command` task and utility - [#1](https://github.com/PrefectHQ/prefect-shell/pull/1)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `cwd` keyword argument in `shell_run_command` - [#41](https://github.com/PrefectHQ/prefect-shell/pull/41)
+
 ### Changed
 
 ### Deprecated
@@ -18,15 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
-
-
-## 0.1.3
-
-Released on October 11th, 2022.
-
-### Added
-
-- Added `cwd` keyword argument in `shell_run_command` - [#41](https://github.com/PrefectHQ/prefect-shell/pull/41)
 
 
 ## 0.1.2

--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -21,6 +21,7 @@ async def shell_run_command(
     extension: Optional[str] = None,
     return_all: bool = False,
     stream_level: int = logging.INFO,
+    cwd: Union[str, bytes, PathLike, None] = None,
 ) -> Union[List, str]:
     """
     Runs arbitrary shell commands.
@@ -40,6 +41,7 @@ async def shell_run_command(
             or just the last line as a string.
         stream_level: The logging level of the stream;
             defaults to 20 equivalent to `logging.INFO`.
+        cwd: The working directory context the command will be executed within
 
     Returns:
         If return all, returns all lines as a list; else the last line as a string.
@@ -78,7 +80,7 @@ async def shell_run_command(
             shell_command = " ".join(shell_command)
 
         lines = []
-        async with await open_process(shell_command, env=current_env) as process:
+        async with await open_process(shell_command, env=current_env, cwd=cwd) as process:
             async for text in TextReceiveStream(process.stdout):
                 logger.log(level=stream_level, msg=text)
                 lines.extend(text.rstrip().split("\n"))

--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -21,7 +21,7 @@ async def shell_run_command(
     extension: Optional[str] = None,
     return_all: bool = False,
     stream_level: int = logging.INFO,
-    cwd: Union[str, bytes, PathLike, None] = None,
+    cwd: Union[str, bytes, os.PathLike, None] = None,
 ) -> Union[List, str]:
     """
     Runs arbitrary shell commands.

--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -80,7 +80,9 @@ async def shell_run_command(
             shell_command = " ".join(shell_command)
 
         lines = []
-        async with await open_process(shell_command, env=current_env, cwd=cwd) as process:
+        async with await open_process(
+            shell_command, env=current_env, cwd=cwd
+        ) as process:
             async for text in TextReceiveStream(process.stdout):
                 logger.log(level=stream_level, msg=text)
                 lines.extend(text.rstrip().split("\n"))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from pathlib import Path
 
 import pytest
 from prefect import flow
@@ -57,6 +58,15 @@ def test_shell_run_command_helper_command():
         return shell_run_command(command="pwd", helper_command="cd $HOME")
 
     assert test_flow() == os.path.expandvars("$HOME")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")
+def test_shell_run_command_cwd():
+    @flow
+    def test_flow():
+        return shell_run_command(command="pwd", cwd=Path.home())
+
+    assert test_flow() == os.fspath(Path.home())
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="see test_commands_windows.py")

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import os
 import sys
+from pathlib import Path
 
 import pytest
 from prefect import flow
@@ -79,6 +80,19 @@ def test_shell_run_command_helper_command_windows():
         )
 
     assert test_flow() == os.path.expandvars("$USERPROFILE")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="see test_commands.py")
+def test_shell_run_command_cwd():
+    @flow
+    def test_flow():
+        return shell_run_command(
+            command="Get-Location",
+            shell="powershell",
+            cwd=Path.home(),
+        )
+
+    assert test_flow() == os.fspath(Path.home())
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="see test_commands.py")


### PR DESCRIPTION
`anyio.open_process()` already implements an argument to execute the process in the context of a given directory in a platform-agnostic way, so delegating that functionality upstream results in one less thing that the user to needs to implement themselves in the helper-script, thus eleminating a potential source of error.

Contributes towards closing #38

### Example
```
from pathlib import Path
from prefect_shell.commands import shell_run_command

home_directory_contents: list[str] = shell_run_command(
    command="ls", cwd=Path.home()
).split("\n")
```

### Checklist
- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-shell/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
 - [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-shell/blob/main/CHANGELOG.md)
