### PR TITLE
Change behaviour of ShellOperation stream_output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Released on February 17, 2023.
 
 ### Changed
-- Change the behaviour of the `ShellOperation` `stream_output` parameter. Setting it to `False` will now only turn of the logging and not send `stdout` and `stderr` to `DEVNULL`. The previous behaviour can be achieved by manually setting `stdout`/`stderr` to `DEVNULL` through the `open_kwargs` arguments. - [#67](https://github.com/PrefectHQ/prefect-shell/issues/67)
+- Change the behavior of the `ShellOperation` `stream_output` parameter. Setting it to `False` will now only turn off the logging and not send `stdout` and `stderr` to `DEVNULL`. The previous behavior can be achieved by manually setting `stdout`/`stderr` to `DEVNULL` through the `open_kwargs` arguments. - [#67](https://github.com/PrefectHQ/prefect-shell/issues/67)
 
 ## 0.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.1.5
+
+Released on February 17, 2023.
+
+### Changed
+- Change the behaviour of the `ShellOperation` `stream_output` parameter. Setting it to `False` will now only turn of the logging and not send `stdout` and `stderr` to `DEVNULL`. The previous behaviour can be achieved by manually setting `stdout`/`stderr` to `DEVNULL` through the `open_kwargs` arguments. - [#67](https://github.com/PrefectHQ/prefect-shell/issues/67)
+
 ## 0.1.4
 
 Released on February 2nd, 2023.

--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -301,8 +301,8 @@ class ShellOperation(JobBlock):
         input_env.update(self.env)
         input_open_kwargs = dict(
             command=trigger_command,
-            stdout=subprocess.PIPE if self.stream_output else subprocess.DEVNULL,
-            stderr=subprocess.PIPE if self.stream_output else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             env=input_env,
             cwd=self.working_dir,
             **open_kwargs,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -164,6 +164,19 @@ class TestShellOperation:
         assert "completed with return code 0" in records[2].message
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
+    async def test_stream_output(self, prefect_task_runs_caplog, method):
+        # If stream_output is False, there should be output,
+        # but no logs from the shell process
+        op = ShellOperation(
+            commands=["echo 'testing\nthe output'", "echo good"], stream_output=False
+        )
+        assert await self.execute(op, method) == ["testing", "the output", "good"]
+        records = prefect_task_runs_caplog.records
+        assert len(records) == 2
+        assert "triggered with 2 commands running" in records[0].message
+        assert "completed with return code 0" in records[1].message
+
+    @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_current_env(self, method):
         op = ShellOperation(commands=["echo $HOME"])
         assert await self.execute(op, method) == [os.environ["HOME"]]


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect-shell/issues/67

Change the behaviour of the `ShellOperation` `stream_output` parameter. Setting it to `False` will now only turn of the logging and not send `stdout` and `stderr` to `DEVNULL`. The previous behaviour can be achieved by manually setting `stdout`/`stderr` to `DEVNULL` through the `open_kwargs` arguments.
### Checklist

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-shell/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] ~Includes screenshots of documentation updates.~
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-shell/blob/main/CHANGELOG.md)
