### PR TITLE
Fix ShellOperation running on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Released on February 17, 2023.
 ### Changed
 - Change the behavior of the `ShellOperation` `stream_output` parameter. Setting it to `False` will now only turn off the logging and not send `stdout` and `stderr` to `DEVNULL`. The previous behavior can be achieved by manually setting `stdout`/`stderr` to `DEVNULL` through the `open_kwargs` arguments. - [#67](https://github.com/PrefectHQ/prefect-shell/issues/67)
 
+### Fixed
+- Using `ShellOperation` on Windows - [#70](https://github.com/PrefectHQ/prefect-shell/issues/70)
+
 ## 0.1.4
 
 Released on February 2nd, 2023.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Install `prefect-shell` with `pip`:
 pip install -U prefect-shell
 ```
 
-A list of available blocks in `prefect-shell` and their setup instructions can be found [here](https://PrefectHQ.github.io/prefect-shell/blocks-catalog).
+A list of available blocks in `prefect-shell` and their setup instructions can be found [here](https://PrefectHQ.github.io/prefect-shell/blocks_catalog).
 
 Requires an installation of Python 3.7+.
 

--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -155,7 +155,7 @@ class ShellProcess(JobRun):
         Capture output from source.
         """
         async for output in TextReceiveStream(source):
-            text = output.rstrip(os.linesep)
+            text = output.rstrip()
             if self._shell_operation.stream_output:
                 self.logger.info(f"PID {self.pid} stream output:{os.linesep}{text}")
             self._output.extend(text.split(os.linesep))

--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -308,7 +308,6 @@ class ShellOperation(JobBlock):
         Helper method to compile the kwargs for `open_process` so it's not repeated
         across the run and trigger methods.
         """
-
         trigger_command = self._exit_stack.enter_context(self._write_trigger_command())
         input_env = os.environ.copy()
         input_env.update(self.env)

--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -155,7 +155,7 @@ class ShellProcess(JobRun):
         Capture output from source.
         """
         async for output in TextReceiveStream(source):
-            text = output.rstrip()
+            text = output.rstrip(os.linesep)
             if self._shell_operation.stream_output:
                 self.logger.info(f"PID {self.pid} stream output:{os.linesep}{text}")
             self._output.extend(text.split(os.linesep))

--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -283,7 +283,6 @@ class ShellOperation(JobBlock):
             f"{temp_file.name!r}:{os.linesep}{joined_commands}"
         )
         temp_file.write(joined_commands.encode())
-        temp_file.flush()
 
         if self.shell is None and sys.platform == "win32" or extension == ".ps1":
             shell = "powershell"
@@ -295,6 +294,7 @@ class ShellOperation(JobBlock):
         if shell == "powershell":
             # if powershell, set exit code to that of command
             temp_file.write("\r\nExit $LastExitCode".encode())
+        temp_file.flush()
 
         trigger_command = [shell, temp_file.name]
         input_env = os.environ.copy()

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -234,7 +234,7 @@ class TestShellOperation:
         assert len(records) == 3
         assert "triggered with 1 commands running" in records[0].message
         assert "testing" in records[1].message
-        assert "completed with return code 0" in records[3].message
+        assert "completed with return code 0" in records[2].message
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_current_env(self, method):

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -138,8 +138,8 @@ def test_shell_run_command_update_current_env_windows():
         )
 
     result = test_flow()
-    assert result[0] == os.environ["USERPROFILE"]
-    assert result[1] == "test value"
+    assert os.environ["USERPROFILE"] in result
+    assert "test value" in result
 
 
 def test_shell_run_command_ensure_suffix_ps1():
@@ -227,13 +227,12 @@ class TestShellOperation:
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_output(self, prefect_task_runs_caplog, method):
-        op = ShellOperation(commands=["echo 'testing\nthe output'", "echo good"])
-        assert await self.execute(op, method) == ["testing\nthe output", "good"]
+        op = ShellOperation(commands=["echo 'testing'"])
+        assert await self.execute(op, method) == ["testing", "good"]
         records = prefect_task_runs_caplog.records
-        assert len(records) == 4
+        assert len(records) == 3
         assert "triggered with 2 commands running" in records[0].message
-        assert "testing\nthe output" in records[1].message
-        assert "good" in records[2].message
+        assert "testing" in records[1].message
         assert "completed with return code 0" in records[3].message
 
     @pytest.mark.parametrize("method", ["run", "trigger"])

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -80,7 +80,7 @@ def test_shell_run_command_helper_command_windows():
             return_all=True,
         )
 
-    assert test_flow() == os.path.expandvars("$USERPROFILE")
+    assert os.path.expandvars("$USERPROFILE") in test_flow()
 
 
 def test_shell_run_command_cwd():
@@ -232,7 +232,7 @@ class TestShellOperation:
         assert await self.execute(op, method) == ["testing"]
         records = prefect_task_runs_caplog.records
         assert len(records) == 3
-        assert "triggered with 2 commands running" in records[0].message
+        assert "triggered with 1 commands running" in records[0].message
         assert "testing" in records[1].message
         assert "completed with return code 0" in records[3].message
 

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -38,7 +38,7 @@ def test_shell_run_command_windows(prefect_task_runs_caplog):
 
     print(prefect_task_runs_caplog.text)
 
-    assert test_flow() == echo_msg
+    assert " ".join(test_flow()) == echo_msg
     for record in prefect_task_runs_caplog.records:
         if "WORKING!!!!" in record.msg:
             break  # it's in the records
@@ -62,7 +62,7 @@ def test_shell_run_command_stream_level_windows(prefect_task_runs_caplog):
 
     print(prefect_task_runs_caplog.text)
 
-    assert test_flow() == echo_msg
+    assert " ".join(test_flow()) == echo_msg
     for record in prefect_task_runs_caplog.records:
         if "WORKING!!!!" in record.msg:
             break  # it's in the records
@@ -217,7 +217,7 @@ class TestShellOperation:
 
     def test_echo(self):
         op = ShellOperation(commands=["echo Hello"])
-        assert op.run() == ["Hello", ""]
+        assert op.run() == ["Hello"]
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_error(self, method):
@@ -232,7 +232,8 @@ class TestShellOperation:
         records = prefect_task_runs_caplog.records
         assert len(records) == 4
         assert "triggered with 2 commands running" in records[0].message
-        assert "stream output:\r\ntesting\nthe output\ngood" in records[1].message
+        assert "testing\nthe output" in records[1].message
+        assert "good" in records[2].message
         assert "completed with return code 0" in records[2].message
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
@@ -245,7 +246,7 @@ class TestShellOperation:
         op = ShellOperation(
             commands=["echo $env:TEST_VAR"], env={"TEST_VAR": "test value"}
         )
-        assert await self.execute(op, method) == ["test value", ""]
+        assert await self.execute(op, method) == ["test value"]
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_cwd(self, method):
@@ -256,7 +257,7 @@ class TestShellOperation:
         async with ShellOperation(commands=["echo 'testing'"]) as op:
             proc = await op.trigger()
             await proc.wait_for_completion()
-            await proc.fetch_result() == ["testing", ""]
+            await proc.fetch_result() == ["testing"]
 
     def test_async_context_manager(self):
         with ShellOperation(commands=["echo 'testing'"]) as op:

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -64,7 +64,7 @@ def test_shell_run_command_stream_level_windows(prefect_task_runs_caplog):
 
     assert test_flow() == echo_msg
     for record in prefect_task_runs_caplog.records:
-        if echo_msg in record.msg:
+        if "WORKING!!!!" in record.msg:
             break  # it's in the records
     else:
         raise AssertionError
@@ -86,7 +86,7 @@ def test_shell_run_command_cwd():
     @flow
     def test_flow():
         return shell_run_command(
-            command="Get-Location",
+            command="echo 'work!'; Get-Location",
             shell="powershell",
             cwd=Path.home(),
         )
@@ -229,7 +229,7 @@ class TestShellOperation:
         op = ShellOperation(commands=["echo 'testing\nthe output'", "echo good"])
         assert await self.execute(op, method) == ["testing\nthe output", "good"]
         records = prefect_task_runs_caplog.records
-        assert len(records) == 3
+        assert len(records) == 4
         assert "triggered with 2 commands running" in records[0].message
         assert "stream output:\ntesting\nthe output\ngood" in records[1].message
         assert "completed with return code 0" in records[2].message

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -27,7 +27,7 @@ def test_shell_run_command_error_windows(prefect_task_runs_caplog):
 
 def test_shell_run_command_windows(prefect_task_runs_caplog):
     prefect_task_runs_caplog.set_level(logging.INFO)
-    echo_msg = "_THIS_ IS WORKING!!!!"
+    echo_msg = "WORKING"
 
     @flow
     def test_flow():
@@ -40,7 +40,7 @@ def test_shell_run_command_windows(prefect_task_runs_caplog):
 
     assert " ".join(test_flow()) == echo_msg
     for record in prefect_task_runs_caplog.records:
-        if "WORKING!!!!" in record.msg:
+        if "WORKING" in record.msg:
             break  # it's in the records
     else:
         raise AssertionError
@@ -48,7 +48,7 @@ def test_shell_run_command_windows(prefect_task_runs_caplog):
 
 def test_shell_run_command_stream_level_windows(prefect_task_runs_caplog):
     prefect_task_runs_caplog.set_level(logging.WARNING)
-    echo_msg = "_THIS_ IS WORKING!!!!"
+    echo_msg = "WORKING"
 
     @flow
     def test_flow():
@@ -64,7 +64,7 @@ def test_shell_run_command_stream_level_windows(prefect_task_runs_caplog):
 
     assert " ".join(test_flow()) == echo_msg
     for record in prefect_task_runs_caplog.records:
-        if "WORKING!!!!" in record.msg:
+        if "WORKING" in record.msg:
             break  # it's in the records
     else:
         raise AssertionError
@@ -234,12 +234,12 @@ class TestShellOperation:
         assert "triggered with 2 commands running" in records[0].message
         assert "testing\nthe output" in records[1].message
         assert "good" in records[2].message
-        assert "completed with return code 0" in records[2].message
+        assert "completed with return code 0" in records[3].message
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_current_env(self, method):
         op = ShellOperation(commands=["echo $env:USERPROFILE"])
-        assert await self.execute(op, method) == [os.environ["USERPROFILE"], ""]
+        assert await self.execute(op, method) == [os.environ["USERPROFILE"]]
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_updated_env(self, method):

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -89,9 +89,10 @@ def test_shell_run_command_cwd():
             command="echo 'work!'; Get-Location",
             shell="powershell",
             cwd=Path.home(),
+            return_all=True,
         )
 
-    assert test_flow() == os.fspath(Path.home())
+    assert os.fspath(Path.home()) in test_flow()
 
 
 def test_shell_run_command_return_all():
@@ -231,7 +232,7 @@ class TestShellOperation:
         records = prefect_task_runs_caplog.records
         assert len(records) == 4
         assert "triggered with 2 commands running" in records[0].message
-        assert "stream output:\ntesting\nthe output\ngood" in records[1].message
+        assert "stream output:\r\ntesting\nthe output\ngood" in records[1].message
         assert "completed with return code 0" in records[2].message
 
     @pytest.mark.parametrize("method", ["run", "trigger"])

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -34,7 +34,7 @@ def test_shell_run_command_windows(prefect_task_runs_caplog):
         msg = shell_run_command(
             command=f"echo {echo_msg}", return_all=True, shell="powershell"
         )
-        return " ".join(word.replace("\r", "") for word in msg)
+        return msg
 
     print(prefect_task_runs_caplog.text)
 
@@ -58,7 +58,7 @@ def test_shell_run_command_stream_level_windows(prefect_task_runs_caplog):
             return_all=True,
             shell="powershell",
         )
-        return " ".join(word.replace("\r", "") for word in msg)
+        return msg
 
     print(prefect_task_runs_caplog.text)
 
@@ -216,7 +216,7 @@ class TestShellOperation:
 
     def test_echo(self):
         op = ShellOperation(commands=["echo Hello"])
-        assert op.run() == ["Hello"]
+        assert op.run() == ["Hello", ""]
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_error(self, method):
@@ -237,14 +237,14 @@ class TestShellOperation:
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_current_env(self, method):
         op = ShellOperation(commands=["echo $env:USERPROFILE"])
-        assert await self.execute(op, method) == [os.environ["USERPROFILE"]]
+        assert await self.execute(op, method) == [os.environ["USERPROFILE"], ""]
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_updated_env(self, method):
         op = ShellOperation(
             commands=["echo $env:TEST_VAR"], env={"TEST_VAR": "test value"}
         )
-        assert await self.execute(op, method) == ["test value"]
+        assert await self.execute(op, method) == ["test value", ""]
 
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_cwd(self, method):
@@ -255,10 +255,10 @@ class TestShellOperation:
         async with ShellOperation(commands=["echo 'testing'"]) as op:
             proc = await op.trigger()
             await proc.wait_for_completion()
-            await proc.fetch_result() == ["testing"]
+            await proc.fetch_result() == ["testing", ""]
 
     def test_async_context_manager(self):
         with ShellOperation(commands=["echo 'testing'"]) as op:
             proc = op.trigger()
             proc.wait_for_completion()
-            proc.fetch_result() == ["testing"]
+            proc.fetch_result() == ["testing", ""]

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -213,7 +213,7 @@ class TestShellOperation:
             proc = await op.trigger()
             await proc.wait_for_completion()
             return await proc.fetch_result()
-        
+
     def test_echo(self):
         op = ShellOperation(commands=["echo Hello"])
         assert op.run() == "Hello"

--- a/tests/test_commands_windows.py
+++ b/tests/test_commands_windows.py
@@ -77,6 +77,7 @@ def test_shell_run_command_helper_command_windows():
             command="Get-Location",
             helper_command="cd $env:USERPROFILE",
             shell="powershell",
+            return_all=True,
         )
 
     assert test_flow() == os.path.expandvars("$USERPROFILE")
@@ -138,7 +139,7 @@ def test_shell_run_command_update_current_env_windows():
         )
 
     result = test_flow()
-    assert os.environ["USERPROFILE"] in result
+    assert os.environ["USERPROFILE"] in " ".join(result)
     assert "test value" in result
 
 
@@ -228,7 +229,7 @@ class TestShellOperation:
     @pytest.mark.parametrize("method", ["run", "trigger"])
     async def test_output(self, prefect_task_runs_caplog, method):
         op = ShellOperation(commands=["echo 'testing'"])
-        assert await self.execute(op, method) == ["testing", "good"]
+        assert await self.execute(op, method) == ["testing"]
         records = prefect_task_runs_caplog.records
         assert len(records) == 3
         assert "triggered with 2 commands running" in records[0].message


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Our Windows test were failing, but the GitHub jobs were marked as successful. This PR fixes the test config, and also fixes running ShellOperation on Windows.

Closes https://github.com/PrefectHQ/prefect-shell/issues/69

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-shell/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-shell/blob/main/CHANGELOG.md)
