### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/prefect_shell/commands.py
+++ b/prefect_shell/commands.py
@@ -17,7 +17,12 @@ from prefect.blocks.abstract import JobBlock, JobRun
 from prefect.logging import get_run_logger
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.processutils import open_process
-from pydantic import DirectoryPath, Field, PrivateAttr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import DirectoryPath, Field, PrivateAttr
+else:
+    from pydantic import DirectoryPath, Field, PrivateAttr
 
 
 @task


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.